### PR TITLE
Fix 2021 warning on panic!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl<E> Handle<E> {
             Ok(r) => r,
             Err(e) => {
                 // propagate the panic
-                panic!(e)
+                std::panic::panic_any(e)
             }
         }
     }


### PR DESCRIPTION
Since [rust 2021](https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html), `panic!` does not accept error but expect a format string. Use panic_any instead.